### PR TITLE
--no-exec always uses verbose output

### DIFF
--- a/retain/__init__.py
+++ b/retain/__init__.py
@@ -204,6 +204,7 @@ class FileRetainer:
         for o, a in opts:
             if o in ("--no-exec", "-n"):
                 self.__no_exec = 1
+                self.__verbose = 1
                 continue
 
             if o in ("--verbose", "-v"):


### PR DESCRIPTION
Since -n/--no-exec gives no output without -v/--verbose, why not have it automatically add the -v behind the scenes?
