### PR TITLE
Asks for confirmation if file not found. Added related --safe/-s and --f...

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ specified in its argument list. Conceptually, it's the opposite of
 
 # Usage
 
-*retain* [OPTIONS] *filename* [...]
+*retain* [-fnrsv] [-d directory] *filename* [...]
 
 ## Options
 
-* `--directory`: The directory to operate on. Defaults to the current directory.
-* `--no-exec` or `-n`: Show what would be done, but don't do it.
+* `--directory` or `-d`: The directory to operate on. Defaults to the current directory.
+* `--force` or `-f`: Do not ask for confirmation if file is not found (overrides any previous `-s` option)
+* `--no-exec` or `-n`: Show what would be done, but don't do it (implies `-v`).
 * `--recursive` or `-r`: Remove subdirectories, too (recursively).
+* `--safe` or `-s`: If a file is not found, program exits, nothing is deleted (overrides any previous `-f` option)
 * `--verbose` or `-v`: Display verbose messages
 
 # Installation

--- a/retain/__init__.py
+++ b/retain/__init__.py
@@ -7,18 +7,18 @@ retain - Command-line utility that removes all files except the ones
 Usage:
 ------
 
-retain [OPTIONS] filename [...]
+retain [-fnrsv] [-d directory] filename [...]
 
 
 Options:
 --------
 
 --directory <dir>   The directory to operate on. Defaults to the current
--d <dir>            directory.
+-d <dir>            directory
 
 --force, -f         Do not ask for confirmation if file to retain          
 
---no-exec, -n       Show what would be done, but do not actually do it.
+--no-exec, -n       Show what would be done, but do not actually do it (implies -v)
 
 --recursive, -r     Delete directories, too (recursively)
 
@@ -73,7 +73,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # $Id$
 
 # Info about the module
-__version__   = '1.1.2'
+__version__   = '2.0.0'
 __author__    = 'Brian Clapper'
 __email__     = 'bmc@clapper.org'
 __url__       = 'http://github.com/bmc/retain'
@@ -254,14 +254,14 @@ class FileRetainer:
                 else:
                     answer = raw_input(fpath + " was not found, continue? (y/n)\n")
                     if answer.lower() != "y":
-                        raise RetainException, "User canceled execution."
+                        raise RetainException, "User canceled execution"
 
     def __usage(self, prog, msg):
         u = [
 "",
 "retain, version %s" % __version__,
 "",
-"Usage: %s [OPTIONS] filename [...]" % os.path.basename(prog),
+"Usage: %s [-fnrsv] [-d directory] filename [...]" % os.path.basename(prog),
 "",
 "Retain all the specified files, removing anything else.",
 "",
@@ -270,7 +270,7 @@ class FileRetainer:
 "--directory <dir>",
 "-d <dir>           Directory to operate on. Defaults to current directory",
 "--force, -f         Do not ask for confirmation if file is not found (overrides any previous -s option)",          
-"--no-exec, -n      Show what would be done, but don't really do it",
+"--no-exec, -n      Show what would be done, but don't really do it (implies -v)",
 "--recursive, -r    Delete directories, too (recursively)",
 "--safe, -s         If a file is not found, program exits, nothing is deleted (overrides any previous -f option)",
 "--verbose, -v      Enable verbose messages"
@@ -306,7 +306,6 @@ def main():
         sys.exit(1)
 
     sys.exit(0)
-
 
 if __name__ == "__main__":
     main()

--- a/retain/__init__.py
+++ b/retain/__init__.py
@@ -73,7 +73,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # $Id$
 
 # Info about the module
-__version__   = '2.0.0'
+__version__   = '2.0.1'
 __author__    = 'Brian Clapper'
 __email__     = 'bmc@clapper.org'
 __url__       = 'http://github.com/bmc/retain'
@@ -163,24 +163,26 @@ class FileRetainer:
             verbose("Retaining " + dirFile)
             return
         
-        verbose("Deleting " + dirFile)
-        if not self.__no_exec:
-            try:
-                mode = os.stat(dirFile)[stat.ST_MODE]
-                if stat.S_ISDIR(mode):
-                    if not self.__recursive:
-                        sys.stderr.write("Skipping directory \"" +
-                                         dirFile +
-                                         "\" because -r (--recursive) " +
-                                         "was not specified.\n");
-                    else:
-                        shutil.rmtree(dirFile)
+        try:
+            mode = os.stat(dirFile)[stat.ST_MODE]
+            if stat.S_ISDIR(mode):
+                if not self.__recursive:
+                    sys.stderr.write("Skipping directory \"" +
+                            dirFile +
+                            "\" because -r (--recursive) " +
+                            "was not specified.\n");
                 else:
+                    verbose("Deleting " + dirFile)
+                    if not self.__no_exec:
+                        shutil.rmtree(dirFile)
+            else:
+                verbose("Deleting " + dirFile)
+                if not self.__no_exec:
                     os.unlink(dirFile)
-        
-            except OSError, ex:
-                sys.stderr.write("Warning: Can't unlink \"" + dirFile +
-                                 "\": " + str (ex) + "\n")
+
+        except OSError, ex:
+            sys.stderr.write("Warning: Can't unlink \"" + dirFile +
+                    "\": " + str (ex) + "\n")
     def __parseParams(self, argv):
         # Parse the command-line parameters
 

--- a/retain/__init__.py
+++ b/retain/__init__.py
@@ -16,9 +16,13 @@ Options:
 --directory <dir>   The directory to operate on. Defaults to the current
 -d <dir>            directory.
 
+--force, -f         Do not ask for confirmation if file to retain          
+
 --no-exec, -n       Show what would be done, but do not actually do it.
 
 --recursive, -r     Delete directories, too (recursively)
+
+"--safe, -s         If a file is not found, program exits, nothing is deleted (overrides any previous -f option)",
 
 --verbose, -v       Enable verbose messages
 
@@ -182,23 +186,21 @@ class FileRetainer:
 
         try:
             opts, args = getopt(argv[1:],
-                                "nvrd:",
+                                "nvrfsd:",
                                 ["directory=",
                                  "no-exec",
                                  "recursive",
-                                 "verbose"])
+                                 "verbose",
+                                 "force",
+                                 "safe"])
         except GetoptError, ex:
             self.__usage(argv[0], str (ex))   # throws an exception
-
-        files = []
-        if len(args) > 0:
-            self.__files = set(args[0:])
-        else:
-            self.__usage(argv[0], "Missing file(s) to retain.")
 
         self.__no_exec   = 0
         self.__verbose   = 0
         self.__recursive = 0
+        self.__force     = 0
+        self.__safe      = 0
         self.__dir       = "."
 
         for o, a in opts:
@@ -219,6 +221,41 @@ class FileRetainer:
                 self.__recursive = 1
                 continue
 
+            if o in ("--force", "-f"):
+                self.__force = 1
+                self.__safe = 0
+                continue
+
+            if o in ("--safe", "-s"):
+                self.__safe = 1
+                self.__force = 0
+                continue
+        
+        files = []
+        if len(args) > 0:
+            self.__files = set(args[0:])
+            
+            if not self.__force:
+                self.__checkFiles(self.__files)
+        else:
+            self.__usage(argv[0], "Missing file(s) to retain.")
+
+
+    def __checkFiles(self, files):
+        for fname in files:
+            if self.__dir != ".":
+                fpath = self.__dir + os.path.sep + fname
+            else:
+                fpath = fname
+
+            if not (os.path.isfile(fpath)) and not (self.__recursive and os.path.isdir(fpath)):
+                if self.__safe:
+                    raise RetainException, fpath + " not found, canceling execution."
+                else:
+                    answer = raw_input(fpath + " was not found, continue? (y/n)\n")
+                    if answer.lower() != "y":
+                        raise RetainException, "User canceled execution."
+
     def __usage(self, prog, msg):
         u = [
 "",
@@ -232,8 +269,10 @@ class FileRetainer:
 "",
 "--directory <dir>",
 "-d <dir>           Directory to operate on. Defaults to current directory",
-"--no-exec, -n      Show what would be done, but don't really do it.",
+"--force, -f         Do not ask for confirmation if file is not found (overrides any previous -s option)",          
+"--no-exec, -n      Show what would be done, but don't really do it",
 "--recursive, -r    Delete directories, too (recursively)",
+"--safe, -s         If a file is not found, program exits, nothing is deleted (overrides any previous -f option)",
 "--verbose, -v      Enable verbose messages"
             ]
 


### PR DESCRIPTION
Asks for confirmation if file not found. Added related --safe/-s and --force/-f options.

I noticed that if you accidentally misspelled a file name when using retain, you were screwed and that file was gone forever. That seemed terribly unsafe, so I made the program ask for confirmation if it found that a file did not exist.

Then, to allow the program to still be useful in scripts where interaction would not be possible, I added --force and --safe. --force causes the program to run as it would have before these changes--ignoring any files that do not exist, and --safe terminates the program if any of the files are not found. 

Exiting via --safe or the user opting not to continue both cause an exit status of 1 and raise an exception.

Since this change isn't backwards compatible with the previous version of the script, I updated the version to 2.0.0 (as per semantic versioning). I'm not sure if that carries over in the pull request or not though. 
